### PR TITLE
Add missing spacing

### DIFF
--- a/docs/Design.md
+++ b/docs/Design.md
@@ -150,7 +150,7 @@ struct EndIncentiveParams {
 
 **Interactions**
 
--`msg.sender` to withdraw all of their reward balance in a specific token to a specified `to` address.
+- `msg.sender` to withdraw all of their reward balance in a specific token to a specified `to` address.
 
 - emit RewardClaimed(to, reward)
 


### PR DESCRIPTION
Without the following space, `-` doesn't render as a bullet point