### PR TITLE
prevent griefing #createIncentive by allowing multiple calls before the incentive starts

### DIFF
--- a/contracts/UniswapV3Staker.sol
+++ b/contracts/UniswapV3Staker.sol
@@ -112,17 +112,7 @@ contract UniswapV3Staker is IUniswapV3Staker, Multicall {
 
         bytes32 incentiveId = IncentiveId.compute(key);
 
-        // totalRewardUnclaimed cannot decrease until key.startTime has passed, meaning this check is safe
-        require(
-            incentives[incentiveId].totalRewardUnclaimed == 0,
-            'UniswapV3Staker::createIncentive: incentive already exists'
-        );
-
-        incentives[incentiveId] = Incentive({
-            totalRewardUnclaimed: reward,
-            totalSecondsClaimedX128: 0,
-            numberOfStakes: 0
-        });
+        incentives[incentiveId].totalRewardUnclaimed += reward;
 
         TransferHelper.safeTransferFrom(address(key.rewardToken), msg.sender, address(this), reward);
 

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `59981`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `57510`;
 
 exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35529`;


### PR DESCRIPTION
alternatives considered:
 - utilizing msg.sender in the hash
 - including initial reward in the incentive key

fixes #203