### PR TITLE
Optimizations

### DIFF
--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,7 @@ const DEFAULT_COMPILER_SETTINGS: SolcUserConfig = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 200,
+      runs: 800,
     },
     metadata: {
       bytecodeHash: 'none',

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -13,7 +13,7 @@ const DEFAULT_COMPILER_SETTINGS: SolcUserConfig = {
   settings: {
     optimizer: {
       enabled: true,
-      runs: 1_000_000,
+      runs: 200,
     },
     metadata: {
       bytecodeHash: 'none',

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `215867`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `215837`;
 
 exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29263`;
 
-exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `76041`;
+exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `76057`;

--- a/test/unit/__snapshots__/Deposits.spec.ts.snap
+++ b/test/unit/__snapshots__/Deposits.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `215336`;
+exports[`unit/Deposits #onERC721Received on successful transfer with staking data has gas cost 1`] = `215867`;
 
-exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29200`;
+exports[`unit/Deposits #transferDeposit has gas cost 1`] = `29263`;
 
-exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `75943`;
+exports[`unit/Deposits #withdrawToken works and has gas cost 1`] = `76041`;

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `57692`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `57681`;
 
-exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35711`;
+exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35655`;

--- a/test/unit/__snapshots__/Incentives.spec.ts.snap
+++ b/test/unit/__snapshots__/Incentives.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `57510`;
+exports[`unit/Incentives #createIncentive works and has gas cost 1`] = `57692`;
 
-exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35529`;
+exports[`unit/Incentives #endIncentive works and has gas cost 1`] = `35711`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `196446`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197571`;
 
-exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `241964`;
+exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243069`;

--- a/test/unit/__snapshots__/Multicall.spec.ts.snap
+++ b/test/unit/__snapshots__/Multicall.spec.ts.snap
@@ -1,5 +1,5 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197571`;
+exports[`unit/Multicall can be used to exit a position from multiple incentives 1`] = `197409`;
 
-exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `243069`;
+exports[`unit/Multicall can be used to stake an already deposited token for multiple incentives 1`] = `242936`;

--- a/test/unit/__snapshots__/Stakes.spec.ts.snap
+++ b/test/unit/__snapshots__/Stakes.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47470`;
+exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47646`;
 
-exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115402`;
+exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115754`;
 
-exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71345`;
+exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71661`;

--- a/test/unit/__snapshots__/Stakes.spec.ts.snap
+++ b/test/unit/__snapshots__/Stakes.spec.ts.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47646`;
+exports[`unit/Stakes #claimReward when requesting the full amount has gas cost 1`] = `47590`;
 
-exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115754`;
+exports[`unit/Stakes #stakeToken works and has gas cost 1`] = `115717`;
 
-exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71661`;
+exports[`unit/Stakes #unstakeToken works and has gas cost 1`] = `71639`;


### PR DESCRIPTION
fixes https://github.com/Uniswap/uniswap-v3-staker/issues/202

Reducing optimization runs to v3-core levels increases gas by about 100 - 500 for reach function. `onERC721Received` with the highest difference of 516 gas (10 cents for 100gwei gas).

Thought I'd post this real quick to display the comparison to help reach a decision on this issue!

``` 
Gas Differences:

onERC721Received: 516
transferDeposit:  63
withdrawToken: 114

createIncentive: 171
endIncentive: 126

claimReward: 120
stakeToken: 330
unstakeToken: 294

```

